### PR TITLE
Add setId to MorphiaModel

### DIFF
--- a/src/main/java/net/binggl/ninja/mongodb/MorphiaModel.java
+++ b/src/main/java/net/binggl/ninja/mongodb/MorphiaModel.java
@@ -21,4 +21,8 @@ public class MorphiaModel implements Serializable {
     public ObjectId getId() {
         return this.objectId;
     }
+    
+    public void setId(ObjectId objectId) {
+        this.objectId = objectId;
+    }
 }


### PR DESCRIPTION
This method is needed when you have a form and the id is a PathParam (for example). In this case your model has a null objectId and you have to set manually the Id to update using `mongoDB.getDatastore().save(myModel);`, if don't, Morphia will create another entry instead of update the older entry.